### PR TITLE
Downgrade oodle-metrics, newer lib versions are broken

### DIFF
--- a/java/lp-service.gradle
+++ b/java/lp-service.gradle
@@ -18,7 +18,7 @@ buildscript {
         oodleCommonsVersion = '0.2.2'
         oodleCloudVersion = '2.3.1'
         oodleJwtVersion = '1.2.1'
-        oodleMetricsVersion = '1.3.1'
+        oodleMetricsVersion = '0.0.8'
         libBffObjectsVersion = 'v1.3.0'
         // Transitive dependency versions forced temporarily to resolve security issues
         snakeYamlVersion = '1.33'


### PR DESCRIPTION
We have a bug ticket outstanding to resolve the compatibility problems with this lib, but for now a sensible default will be version 0.0.8. The security issues seem to be resolved with the spring boot BOM anyway