### PR TITLE
remove range on transitive dep version constraint

### DIFF
--- a/java/lp-service.gradle
+++ b/java/lp-service.gradle
@@ -76,15 +76,15 @@ dependencies {
             // Transitive dependency of spring boot, should be resolved in version 3
             because 'Version < 1.33 has vulnerabilities reported by the OWASP dependency checker'
         }
-        implementation('org.springframework.security:spring-security-web:[5.7.5,)') {
+        implementation('org.springframework.security:spring-security-web:5.7.5') {
             // Transitive dependency of spring boot, should be resolved with spring boot > 2.7.5
             because '5.7.4 and earlier are affected by CVEs'
         }
-        implementation('org.springframework.security:spring-security-config:[5.7.5,)') {
+        implementation('org.springframework.security:spring-security-config:5.7.5') {
             // Transitive dependency of spring boot, should be resolved with spring boot > 2.7.5
             because '5.7.4 and earlier are affected by CVEs'
         }
-        implementation("com.fasterxml.woodstox:woodstox-core:[6.4.0,)"){
+        implementation("com.fasterxml.woodstox:woodstox-core:6.4.0"){
             // Transitive dependency of apache CXF, should be resolved with versions after 3.5.4
             because '6.3.1 and earlier are affected by CVEs'
         }


### PR DESCRIPTION
Turns out this doesn't work as I thought it did. Leaving a fixed version is safer.