### PR TITLE
Add parent script for spring boot 3

### DIFF
--- a/java/lp-service-spring-boot-3.gradle
+++ b/java/lp-service-spring-boot-3.gradle
@@ -1,0 +1,108 @@
+// Shared gradle script for java services using spring boot 3.x and dependency locking
+
+import java.text.SimpleDateFormat
+
+println 'Project using lp-service-spring-boot-3 script as of ' + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
+
+buildscript {
+    ext {
+        devopsGradleDir = "${rootDir}/oodle-devops/gradle"
+
+        springBootVersion = '3.+' // Version used for gradle plugin AND framework dependencies
+        // Plugin versions
+        dependencyCheckVersion = '7.+'
+        versionsPluginVersion = '+'
+        // Versions for dependencies included in this script
+        lpBomVersion = '1.+'
+        lombokVersion = '1.+'
+        oodleLoggingVersion = '1.+'
+        logstashEncoderVersion = '7.+'
+    }
+    // Repository block for sourcing plugins
+    repositories {
+        maven {
+            url "https://${codeartifactDomain}-${awsBuildAccountId}.d.codeartifact.eu-west-1.amazonaws.com/maven/oodle-maven-repo/"
+            credentials {
+                username "${codeartifactUser}"
+                password "${codeartifactToken}"
+            }
+        }
+    }
+    dependencies {
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+        classpath "org.owasp:dependency-check-gradle:${dependencyCheckVersion}"
+        classpath "com.github.ben-manes:gradle-versions-plugin:${versionsPluginVersion}"
+    }
+}
+
+apply plugin: 'java'
+// In order to provide plugins for other projects sourcing this script, we must specify the plugins by type
+// See https://blog.mrhaki.com/2015/10/gradle-goodness-apply-external-script.html
+
+apply plugin: org.springframework.boot.gradle.plugin.SpringBootPlugin
+apply plugin: org.owasp.dependencycheck.gradle.DependencyCheckPlugin
+apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
+
+// Repository block for sourcing dependencies
+repositories {
+    maven {
+        url "https://${codeartifactDomain}-${awsBuildAccountId}.d.codeartifact.eu-west-1.amazonaws.com/maven/oodle-maven-repo/"
+        credentials {
+            username "${codeartifactUser}"
+            password "${codeartifactToken}"
+        }
+    }
+}
+
+dependencyLocking {
+    // Enable locking of dependency versions using '--write-locks' to generate a `gradle.lockfile`
+    lockAllConfigurations()
+}
+
+dependencies {
+    implementation platform("com.oodlefinance.loanprocessing:lp-service-bom:${lpBomVersion}")
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}"
+
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+    implementation "net.logstash.logback:logstash-logback-encoder:${logstashEncoderVersion}"
+    implementation "com.oodlefinance:logging:${oodleLoggingVersion}"
+
+}
+
+sourceCompatibility = JavaVersion.valueOf(javaVersion)
+
+// Use a timestamp for a version number
+project.version = new SimpleDateFormat("'v'yyyyMMddHHmmss").format(new Date())
+
+// Add additional tasks from oodle-devops repo, as used in jenkinsfile:
+def publishArtifacts = new File("${devopsGradleDir}/publishArtifacts.gradle")
+def qualityChecks = new File("${devopsGradleDir}/qualityChecks.gradle")
+def sonarQube = new File("${devopsGradleDir}/sonarQube.gradle")
+
+if (publishArtifacts.exists()) apply from: publishArtifacts
+if (qualityChecks.exists()) apply from: qualityChecks
+if (sonarQube.exists()) apply from: sonarQube
+
+bootJar {
+    archiveFileName = "${rootProject.name.toLowerCase()}.jar"
+    manifest {
+        attributes(
+                'Implementation-Version': project.version,
+                'Bundle-SymbolicName': project.group,
+                'Git-commit-hash': "git rev-parse --verify HEAD".execute().text.trim()
+        )
+    }
+}
+
+test {
+    useJUnitPlatform()
+    systemProperty 'spring.profiles.active', 'test'
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}


### PR DESCRIPTION
To replace lp-service-dynamic once all our services are moved over to this.

In comparison with the existing script I've just swapped the spring boot version updated some comments, and removed the block that ran the dependency tasks - on the whole this makes the output quite spammy and isn't needed with locking.

```
diff java/lp-service-dynamic.gradle java/lp-service-spring-boot-3.gradle
1c1
< // Shared gradle script for java services using spring boot 2.x and dependency locking
---
> // Shared gradle script for java services using spring boot 3.x and dependency locking
5c5
< println 'Project using lp-service-dynamic script as of ' + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
---
> println 'Project using lp-service-spring-boot-3 script as of ' + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
11c11
<         springBootVersion = '2.+' // Version used for gradle plugin AND framework dependencies
---
>         springBootVersion = '3.+' // Version used for gradle plugin AND framework dependencies
90,97d89
<
<
< build {
<     // Before each build, run dependencyUpdates from gradle-versions-plugin
<     // This gives a convenient log of all dependency versions used in a build
<     dependsOn(tasks.getByName('dependencyUpdates'))
<     dependsOn(tasks.getByName('dependencies'))
< }
```