### PR TITLE
Fix version of spring boot plugin

### DIFF
--- a/java/lp-service-spring-boot-3.gradle
+++ b/java/lp-service-spring-boot-3.gradle
@@ -29,7 +29,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:3.2.2"
         classpath "org.owasp:dependency-check-gradle:${dependencyCheckVersion}"
         classpath "com.github.ben-manes:gradle-versions-plugin:${versionsPluginVersion}"
     }


### PR DESCRIPTION
Later versions are incompatible with gradle 7.4, breaking builds.

This is not an ideal solution but likely this plugin version will work for the rest of spring boot 3.x. We can have a nicer approach (perhaps parameterised from the project) for spring boot 4.