### PR TITLE
Add main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,10 @@
+name: Push to main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    uses: oodlefinance/github-actions/.github/workflows/create-timestamp-tag.yaml@main


### PR DESCRIPTION
Currently only tags the latest commit with a timestamp like our images.

Do we want to have a semantic versioning instead? Could be just an incrementing integer. Would need a bit more work to figure out how to do it.

The main benefit I see is readability. Would be happy to look into adding it if you guys want.