### PR TITLE
LPT-3102: fixing xmlReportPaths after gradle upgrade - jacocoTestReport.reports.xml.destination to jacocoTestReport.reports.xml.outputLocation.get().asFile.absolutePath

### DIFF
--- a/java/lp-service-testing.gradle
+++ b/java/lp-service-testing.gradle
@@ -161,6 +161,6 @@ sonar {
     properties {
         property 'sonar.organization', "${sonarOrganization}"
         property "sonar.host.url", "${sonarHost}"
-        property 'sonar.coverage.jacoco.xmlReportPaths', jacocoTestReport.reports.xml.destination
+        property 'sonar.coverage.jacoco.xmlReportPaths', jacocoTestReport.reports.xml.outputLocation.get().asFile.absolutePath
     }
 }


### PR DESCRIPTION
Fixing sona error after gradle upgrade
https://github.com/oodlefinance/verification-checks-service/actions/runs/12690545923/job/35371631679
![image](https://github.com/user-attachments/assets/d01f0036-95a6-4465-81f8-c2bf9a39934f)
