### PR TITLE
LPT-3783: Remove Snakeyaml exclusion

### DIFF
--- a/java/lp-service.gradle
+++ b/java/lp-service.gradle
@@ -87,8 +87,6 @@ configurations {
     }
     intTestImplementation.extendsFrom testImplementation
     intTestRuntimeOnly.extendsFrom testRuntimeOnly
-    // Exclude snakeyaml entirely - we're not parsing yaml and we see repeated security issues with it
-    all*.exclude group: 'org.yaml', module:'snakeyaml'
 }
 
 bootJar {


### PR DESCRIPTION
This library no longer has any active CVEs, hence we can remove the exclusion